### PR TITLE
Handle missing sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- Returned HTTP 410 Gone status code on missing session ID. See "Error handling" in the README.md.
+
 ## 1.1.0 (2023-10-25)
 
 - Added support for saving context to a Redis store. See "Storing Component Context" in the README.md.

--- a/README.md
+++ b/README.md
@@ -348,3 +348,29 @@ class Sample(LiveComponent):
         effective_kwargs = {**component_kwargs, "var": var}
         return SampleState(**effective_kwargs)
 ```
+
+## Error handling
+
+The response to calling the command can be an HTTP error. If the command handler fails to find a session, it will return
+an HTTP 410 Gone error.
+
+You can handle this error on the client side. For example, here a JavaScript code snippet to reload the page on the
+error 410.
+
+```javascript
+document.addEventListener("htmx:responseError", function (event) {
+	const statusCode = event.detail.xhr.status;
+	if (statusCode === 410) {
+		document.location.reload();
+	}
+});
+```
+
+If you use [hyperscript](https://hyperscript.org/), you can write the same code much shorter as a one-liner, attached
+directly to the component, or to the document:
+
+```html
+<body ... _="on htmx:responseError[detail.xhr.status == 410] window.location.reload()">
+...
+</body>
+```

--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -10,6 +10,7 @@
   <script src="https://unpkg.com/htmx.org@1.9.6"></script>
   <script src="https://unpkg.com/htmx.org/dist/ext/json-enc.js"></script>
   <script src="https://unpkg.com/idiomorph/dist/idiomorph-ext.min.js"></script>
+  <script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
   {% django_htmx_script %}
 
   {% component_css_dependencies %}
@@ -25,7 +26,10 @@
     })
   </script>
 </head>
-<body hx-ext="morph, json-enc" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+<body hx-ext="morph, json-enc"
+      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+      _="on htmx:responseError[detail.xhr.status == 410] window.location.reload()"
+>
 <main class="container">
   <nav>
     <ul>
@@ -37,6 +41,10 @@
   <hr>
   {% block body %}{% endblock %}
 </main>
+<hr>
+<footer class="container">
+  <a hx-post="{% url 'livecomponents:clear-session' %}?session_id={{ LIVECOMPONENTS_SESSION_ID }}" href="#">Clear Session</a>
+</footer>
 
 {% component_js_dependencies %}
 </body>

--- a/livecomponents/manager/manager.py
+++ b/livecomponents/manager/manager.py
@@ -77,8 +77,11 @@ class StateManager:
             return html_bytes.decode("utf-8")
         return None
 
-    def is_component_initialized(self, state_addr: StateAddress) -> bool:
-        return self.store.is_component_initialized(state_addr)
+    def session_exists(self, session_id: str) -> bool:
+        return self.store.session_exists(session_id)
+
+    def component_initialized(self, state_addr: StateAddress) -> bool:
+        return self.store.component_initialized(state_addr)
 
     def get_or_create_component_state(
         self,

--- a/livecomponents/templatetags/livecomponents.py
+++ b/livecomponents/templatetags/livecomponents.py
@@ -199,7 +199,7 @@ class LiveComponentNode(ComponentNode):
         from livecomponents.manager import get_state_manager
 
         state_manager = get_state_manager()
-        if state_manager.is_component_initialized(state_addr):
+        if state_manager.component_initialized(state_addr):
             effective_context = {
                 "request": context["request"],
                 "LIVECOMPONENTS_SESSION_ID": context["LIVECOMPONENTS_SESSION_ID"],

--- a/livecomponents/views.py
+++ b/livecomponents/views.py
@@ -4,6 +4,7 @@ from typing import Any
 from django.http import HttpRequest, HttpResponse
 from django.template import RequestContext, Template
 
+from livecomponents.logging import logger
 from livecomponents.manager import get_state_manager
 from livecomponents.manager.manager import CallContext
 from livecomponents.types import CallMethodRequestArgs, StateAddress
@@ -15,6 +16,12 @@ def call_command(request: HttpRequest):
     args = CallMethodRequestArgs(**request.GET.dict())
     state_manager = get_state_manager()
     kwargs = parse_json_body(request)
+
+    if not state_manager.session_exists(args.session_id):
+        logger.warning(
+            "Session %s does not exist. It may have expired", args.session_id
+        )
+        return HttpResponse("Session does not exist. It may have expired", status=410)
 
     call_context = state_manager.call_component_method(
         request,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,18 @@
 import os
 
+import pytest
+
+from livecomponents.manager import get_state_manager
+
 # Playwright runs the async loop which makes Django raising a SynchronousOnlyOperation
 # exception. This is a workaround to allow async code in tests.
 # See more, for example, in
 # https://github.com/microsoft/playwright-python/issues/439#issuecomment-763339612
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+
+
+@pytest.fixture
+def state_manager():
+    state_manager = get_state_manager()
+    state_manager.store.clear_all_sessions()
+    return state_manager

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,6 @@ import re
 from django import template
 from django.template.loader import render_to_string
 
-from livecomponents.manager import get_state_manager
 from livecomponents.manager.manager import CallContext
 from livecomponents.types import StateAddress
 from livecomponents.views import re_render_component
@@ -11,9 +10,7 @@ from livecomponents.views import re_render_component
 register = template.Library()
 
 
-def test_parser(rf):
-    get_state_manager().store.client.flushall()
-
+def test_parser(rf, state_manager):
     session_id = "foo"
 
     request = rf.get("/")
@@ -24,7 +21,6 @@ def test_parser(rf):
         r'<div data-livecomponent-id="/sample\.0".*>BODYOVERRIDE</div>', rendered
     )
 
-    state_manager = get_state_manager()
     state_address = StateAddress(session_id=session_id, component_id="/sample.0")
     state = state_manager.get_component_state(state_address)
     call_context = CallContext(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,15 @@
+from urllib.parse import urlencode
+
+from django.urls import reverse
+
+
+def test_missing_session_returns_410_gone(client, state_manager):
+    url = reverse("livecomponents:call-command")
+    kwargs = {
+        "session_id": "nonexistent",
+        "component_id": "/sample.0",
+        "command_name": "set_body",
+    }
+    full_url = f"{url}?{urlencode(kwargs)}"
+    resp = client.post(full_url, data={}, content_type="application/json")
+    assert resp.status_code == 410


### PR DESCRIPTION
Make the server return an HTTP 410 Gone status code when the
client send the request to a non-existent (expired) session.

Add documentation, tests and a "Clear Session" button to the example.
