### PR TITLE
Pass component_kwargs when calling get_extra_context_data()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- Modified get_extra_context_data() method to accept component_kwargs, allowing extra context population from parent components without storing in Redis. Note: This change is backward incompatible, altering the method signature to include **component_kwargs.
+
 ## 1.6.0 (2023-12-05)
 
 - Added {% component_ancestor %} templatetag.

--- a/example/coffee/components/coffee/table/table.py
+++ b/example/coffee/components/coffee/table/table.py
@@ -14,7 +14,7 @@ class TableState(LiveComponentsModel):
 class TableComponent(LiveComponent[TableState]):
     template_name = "coffee/table/table.html"
 
-    def get_extra_context_data(self, state: TableState):
+    def get_extra_context_data(self, state: TableState, **component_kwargs):
         if state.search:
             beans = CoffeeBean.objects.filter(
                 Q(name__icontains=state.search)

--- a/example/counters/components/clickcounter/clickcounter.py
+++ b/example/counters/components/clickcounter/clickcounter.py
@@ -16,7 +16,9 @@ class ClickCounterState(BaseModel):
 class ClickCounter(LiveComponent[ClickCounterState]):
     template_name = "clickcounter/clickcounter.html"
 
-    def get_extra_context_data(self, state: ClickCounterState) -> dict[str, Any]:
+    def get_extra_context_data(
+        self, state: ClickCounterState, **component_kwargs
+    ) -> dict[str, Any]:
         return {"value_str": f"{state.value:,}"}
 
     def init_state(

--- a/example/modals/components/emailsender/emailsender.py
+++ b/example/modals/components/emailsender/emailsender.py
@@ -14,7 +14,9 @@ class EmailSenderState(BaseModel):
 class EmailSender(LiveComponent[EmailSenderState]):
     template_name = "emailsender/emailsender.html"
 
-    def get_extra_context_data(self, state: EmailSenderState) -> dict[str, Any]:
+    def get_extra_context_data(
+        self, state: EmailSenderState, **component_kwargs
+    ) -> dict[str, Any]:
         return {}
 
     def init_state(

--- a/example/modals/components/modal/modal.py
+++ b/example/modals/components/modal/modal.py
@@ -14,7 +14,9 @@ class ModalState(BaseModel):
 class Modal(LiveComponent[ModalState]):
     template_name = "modal/modal.html"
 
-    def get_extra_context_data(self, state: ModalState) -> dict[str, Any]:
+    def get_extra_context_data(
+        self, state: ModalState, **component_kwargs
+    ) -> dict[str, Any]:
         return {}
 
     def init_state(self, context: InitStateContext, **component_kwargs) -> ModalState:

--- a/livecomponents/component.py
+++ b/livecomponents/component.py
@@ -75,7 +75,7 @@ class LiveComponent(component.Component, Generic[State], metaclass=LiveComponent
             component_kwargs,
         )
 
-        extra_context = self.get_extra_context_data(state)
+        extra_context = self.get_extra_context_data(state, **component_kwargs)
         context = {
             **component_kwargs,
             **state.model_dump(),
@@ -86,8 +86,25 @@ class LiveComponent(component.Component, Generic[State], metaclass=LiveComponent
         }
         return context
 
-    def get_extra_context_data(self, state: State):
-        """Optionally add additional context data to the component."""
+    def get_extra_context_data(self, state: State, **component_kwargs) -> dict:
+        """Optionally add additional context data to the component.
+
+        Override this method to add additional context data to the component.
+
+        Args:
+            state: The state of the component, that's been previously initialized
+                by `init_state`. The state is stored in Redis and is maintained
+                between re-renders of the component.
+            component_kwargs: The keyword arguments passed to the component in the
+                template tag. For example, if the component is rendered with
+                `{% component "mycomponent" foo="bar" %}`, then `component_kwargs`
+                will be `{"foo": "bar"}`. Remember that when the component is
+                re-rendered as a result of the command execution, no component
+                kwargs are passed.
+
+        Returns:
+            A dictionary with extra context to render the component template.
+        """
         return {}
 
     @abc.abstractmethod

--- a/livecomponents/management/commands/_templates.py
+++ b/livecomponents/management/commands/_templates.py
@@ -22,7 +22,25 @@ class {class_name}State(LiveComponentsModel):
 class {class_name}Component(LiveComponent[{class_name}State]):
     template_name = "{component_name}/{proper_name}.html"
 
-    def get_extra_context_data(self, state: {class_name}State) -> dict[str, Any]:
+    def get_extra_context_data(
+        self, state: {class_name}State, **component_kwargs
+    ) -> dict[str, Any]:
+        \"\"\"Return extra context to render the component template.
+
+        Args:
+            state: The state of the component, that's been previously initialized
+                by `init_state`. The state is stored in Redis and is maintained
+                between re-renders of the component.
+            component_kwargs: The keyword arguments passed to the component in the
+                template tag. For example, if the component is rendered with
+                `{% component "mycomponent" foo="bar" %}`, then `component_kwargs`
+                will be `{"foo": "bar"}`. Remember that when the component is
+                re-rendered as a result of the command execution, no component
+                kwargs are passed.
+
+        Returns:
+            A dictionary with extra context to render the component template.
+        \"\"\"
         return {{}}
 
     def init_state(


### PR DESCRIPTION
Previous version only allows populating the context from the state that
needs to be persisted in the store.

However, sometimes it's helpful to populate extra context from the data
passed by parent components without populating Redis with them.

These changes are backward incompatible and require changing the
signature of all get_extra_context_data() methods from:

    def get_extra_context_data(self, state: State) -> dict:

to:

    def get_extra_context_data(self, state: State, **component_kwargs) -> dict:
