### PR TITLE
Keep sessions marked as deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- Kept sessions marked as deleted for an hour before purging them from the Redis store. This change is to allow the client to recover from a session deletion when the user navigates back to the page.
+
 ## 1.10.0 (2024-01-25)
 
 - Added CancelRendering() exception. The exception makes it possible to cancel the command execution and return an empty string instead of a half-rendered component or an exception.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from livecomponents.manager import get_state_manager
+from livecomponents.manager.stores import RedisStateStore
 
 # Playwright runs the async loop which makes Django raising a SynchronousOnlyOperation
 # exception. This is a workaround to allow async code in tests.
@@ -16,3 +17,11 @@ def state_manager():
     state_manager = get_state_manager()
     state_manager.store.clear_all_sessions()
     return state_manager
+
+
+@pytest.fixture
+def redis_state_store():
+    redis_url = os.environ.get("REDIS_URL")
+    if not redis_url:
+        pytest.skip("Redis URL not provided")
+    return RedisStateStore(redis_url=redis_url)

--- a/tests/test_redis_state_store.py
+++ b/tests/test_redis_state_store.py
@@ -1,0 +1,51 @@
+from livecomponents.types import StateAddress
+
+
+def test_save_state_sets_ttl(redis_state_store):
+    state_addr = StateAddress(session_id="session_id", component_id="|root:0")
+    state = b"state"
+    redis_state_store.save_state(state_addr, state)
+
+    # A bit less than ttl
+    state_key = get_state_key(redis_state_store, state_addr)
+    assert (
+        redis_state_store.client.ttl(state_key)
+        > redis_state_store.ttl.total_seconds() - 10
+    )
+
+
+def test_clear_session_sets_ttl_gc(redis_state_store):
+    session_id = "session_id"
+    state_addr = StateAddress(session_id=session_id, component_id="|root:0")
+    state = b"state"
+    redis_state_store.save_state(state_addr, state)
+
+    # A bit less than ttl_gc
+    redis_state_store.clear_session(session_id)
+    state_key = get_state_key(redis_state_store, state_addr)
+    assert (
+        redis_state_store.client.ttl(state_key)
+        <= redis_state_store.ttl_gc.total_seconds()
+    )
+
+
+def test_clear_session_and_then_save_state_recovers_ttl(redis_state_store):
+    session_id = "session_id"
+    state_addr = StateAddress(session_id=session_id, component_id="|root:0")
+    state = b"state"
+    redis_state_store.save_state(state_addr, state)
+    redis_state_store.clear_session(session_id)
+    redis_state_store.save_state(state_addr, state)
+
+    # A bit less than ttl again
+    state_key = get_state_key(redis_state_store, state_addr)
+    assert (
+        redis_state_store.client.ttl(state_key)
+        > redis_state_store.ttl.total_seconds() - 10
+    )
+
+
+def get_state_key(redis_state_store, state_addr):
+    return redis_state_store._get_key_name(
+        redis_state_store.key_prefix, state_addr.session_id
+    )


### PR DESCRIPTION
Keep sessions marked as deleted for an hour before purging them from
the Redis store. This change is to allow the client to recover from a
session deletion when the user navigates back to the page.
