### PR TITLE
Custom pickler

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Or like this, with explicitly setting the child own_id:
 
     state_address.component_id | ("child_component", "child_own_id")
 
-## On component states
+## Component State
 
 
 The state is defined in a separate class. The state must include parameters, passed to the component as keyword arguments, so that the component gets all necessary information to re-render itself on partial render.
@@ -198,6 +198,23 @@ class Alert(LiveComponent):
 Component states don't need to be stored if components are not expected to be re-rendered independently, and only
 as part of the parent component. For example, components for buttons are rarely re-rendered independently, so
 you get away without the state model.
+
+## Serializing Component State
+
+When the page is rendered for the first time, a new session is created, and each component is initialized with its
+state by calling the `init_state()` method.
+
+The state is then serialized and stored in the session store, and as long as the session is the same (in other words,
+while the page is not loaded), the state is reused.
+
+The state is serialized using the `StateSerializer` class and saved in Redis. By default, the `PickleStateSerializer`
+is used. The serializer uses custom pickler and is optimized to store effectively the most common types of data, used
+in a Django app. More specifically:
+
+- When serializing a Django model, only the model's name and primary key are stored. The serializer takes advantage of
+  the persistent_id/persistent_load pickle mechanism.
+- When serializing a Pydantic model, only the model's name and the values of the fields are stored.
+- When serializing a Django form, only the form's class name, as well as initial data and data, are stored.
 
 
 ## Stateless components

--- a/example/templates/registration.html
+++ b/example/templates/registration.html
@@ -2,5 +2,5 @@
 {% load livecomponents component_tags %}
 
 {% block body %}
-  {% livecomponent "registration_form" %}
+  {% livecomponent "registration_form" email="foo@example.com" %}
 {% endblock %}

--- a/livecomponents/manager/serializers.py
+++ b/livecomponents/manager/serializers.py
@@ -1,9 +1,16 @@
 import abc
-import copyreg
+import io
 import pickle
+import pickletools
 from typing import Any
 
+from django.apps import apps
+from django.db.models import Model
+from django.forms import Form
 from django.forms.renderers import DjangoTemplates
+from pydantic import BaseModel
+
+from livecomponents.logging import logger
 
 
 class IStateSerializer(abc.ABC):
@@ -18,16 +25,105 @@ class IStateSerializer(abc.ABC):
 
 class PickleStateSerializer(IStateSerializer):
     def deserialize(self, raw_state: bytes) -> Any:
-        return pickle.loads(raw_state)
+        unpickler = LivecomponentsUnpickler(io.BytesIO(raw_state))
+        return unpickler.load()
 
     def serialize(self, state: Any) -> bytes:
-        return pickle.dumps(state)
+        buf = io.BytesIO()
+        pickler = LivecomponentsPickler(buf)
+        pickler.dump(state)
+        optimized = pickletools.optimize(buf.getvalue())
+        logger.debug("Serialized state size: %d bytes", len(optimized))
+        return optimized
 
 
-def pickle_django_templates(instance):
+class LivecomponentsPickler(pickle.Pickler):
+    """Pickler that supports more effective pickling of some objects.
+
+    - For Django forms: pickle the form initial state and data. Makes it possible
+      to store fewer data in the state and avoid pickling the entire form instance.
+    - For Pydantic model: pickle the model's dict representation.
+      When restoring the state, the model will be reconstructed from the dict, which
+      makes it possible to evolve the model's fields without breaking the state.
+    - For Django templates: pickle the DjangoTemplates renderer.
+    - For Django models: use persistent_id to pickle the model by its primary key.
+    """
+
+    def reducer_override(self, obj):
+        if isinstance(obj, DjangoTemplates):
+            return pickle_django_templates(obj)
+        if isinstance(obj, Form):
+            return pickle_django_form(obj)
+        if isinstance(obj, BaseModel):
+            return pickle_pydantic_model(obj)
+        return NotImplemented
+
+    def persistent_id(self, obj):
+        if isinstance(obj, Model):
+            logger.debug(
+                "Custom pickling: Django model with persistent_id: class=%s, pk=%s",
+                obj.__class__,
+                obj.pk,
+            )
+            return "django_model", obj._meta.app_label, obj._meta.model_name, obj.pk
+        return None
+
+
+class LivecomponentsUnpickler(pickle.Unpickler):
+    def persistent_load(self, pid):
+        type_tag, app_label, model_name, pk = pid
+        if type_tag == "django_model":
+            logger.debug(
+                "Custom unpickling: Django model with persistent_id: "
+                "app_label=%s, model_name=%s, pk=%s",
+                app_label,
+                model_name,
+                pk,
+            )
+            model_class = apps.get_model(app_label, model_name)
+            return model_class.objects.get(pk=pk)
+        raise pickle.UnpicklingError(f"Unsupported persistent id: {pid}")
+
+
+def pickle_django_templates(instance: DjangoTemplates):
+    """Custom pickler for DjangoTemplates renderer.
+
+    See https://stackoverflow.com/a/77286987
+    """
+    logger.debug(
+        "Custom pickling: DjangoTemplates renderer: class=%s", instance.__class__
+    )
     return DjangoTemplates, ()
 
 
-# Register a custom handler for pickling DjangoTemplates renderer
-# See https://stackoverflow.com/a/77286987
-copyreg.pickle(DjangoTemplates, pickle_django_templates)
+def pickle_django_form(instance: Form):
+    logger.debug(
+        "Custom pickling: Form with initial and data: class=%s", instance.__class__
+    )
+    data = instance.data if instance.is_bound else None
+    return unpickle_django_form, (instance.__class__, instance.initial, data)
+
+
+def unpickle_django_form(cls, initial: dict | None, data: dict | None):
+    logger.debug(
+        "Custom unpickling: Form with initial and data: class=%s", cls.__name__
+    )
+    return cls(initial=initial, data=data)
+
+
+def pickle_pydantic_model(instance: BaseModel):
+    logger.debug(
+        "Custom pickling: Pydantic model with model_dump: class=%s",
+        instance.__class__,
+    )
+    return unpickle_pydantic_model, (
+        instance.__class__,
+        instance.model_dump(),
+    )
+
+
+def unpickle_pydantic_model(cls, model_dict: dict):
+    logger.debug(
+        "Custom unpickling: Pydantic model with model_dump: class=%s", cls.__name__
+    )
+    return cls(**model_dict)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,82 @@
+import io
+from pickletools import dis, genops
+
+import pytest
+from coffee.models import CoffeeBean
+from django import forms
+from pydantic import BaseModel
+
+from livecomponents.manager.serializers import PickleStateSerializer
+
+
+class MyModel(BaseModel):
+    foo: str
+
+
+class MyForm(forms.Form):
+    name = forms.CharField(max_length=100)
+
+
+@pytest.mark.parametrize(
+    "obj, expected_arg",
+    [
+        (MyModel(foo="bar"), "unpickle_pydantic_model"),
+        (MyForm(initial={"name": "foo"}, data={"name": "bar"}), "unpickle_django_form"),
+        (CoffeeBean(id=1), "django_model"),
+    ],
+)
+def test_pickle_state_serializer_pydantic_model(obj, expected_arg):
+    serialized = PickleStateSerializer().serialize(obj)
+    for _, arg, _ in genops(serialized):
+        if arg == expected_arg:
+            return
+    debug = io.StringIO()
+    dis(serialized, out=debug)
+    raise AssertionError(
+        f"Unexpected pickle result for {obj!r}\n"
+        f"Dumped value:\n"
+        f"{debug.getvalue()}\n"
+        f"Missing opcode: {expected_arg}\n"
+    )
+
+
+@pytest.mark.django_db
+def test_django_serialization():
+    bean = CoffeeBean.objects.create(
+        name="Bean", origin="Origin", roast_level="Roast", flavor_notes="Notes"
+    )
+    deserialized = reserialize(bean)
+    assert deserialized == bean
+
+
+def test_pydantic_serialization():
+    model = MyModel(foo="bar")
+    deserialized = reserialize(model)
+    assert deserialized == model
+
+
+def test_form_serialization():
+    form = MyForm(initial={"name": "foo"}, data={"name": "bar"})
+    deserialized = reserialize(form)
+    assert deserialized.initial == {"name": "foo"}
+    assert deserialized.data == {"name": "bar"}
+
+
+def test_form_serialization_with_data():
+    form = MyForm(data={"name": "bar"})
+    assert form.is_bound is True
+
+    deserialized = reserialize(form)
+    assert deserialized.is_bound is True
+
+
+def test_form_serializarion_without_data():
+    form = MyForm(initial={"name": "foo"})
+    assert form.is_bound is False
+
+    deserialized = reserialize(form)
+    assert deserialized.is_bound is False
+
+
+def reserialize(obj):
+    return PickleStateSerializer().deserialize(PickleStateSerializer().serialize(obj))


### PR DESCRIPTION
Implement LivecomponentsPickler and LivecomponentsUnpickler
to implement custom serialization and deserialization logic for some
common Python types.

- Django models: store only the model name and PK.
- Pydantic models: store the model class and dumped model.
- Django forms: store initial and data.

Remove a workaround with custom form data
serialization from the example.

## Video

https://www.loom.com/share/948a42fbeee0493ca9031df2eba0b0e6
