### PR TITLE
`docs/quickstart.md`: Document that `safer_staticfiles` replaces `staticfiles`

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,7 +14,7 @@ Add to installed apps following packages:
 INSTALLED_APPS = [
     # ...
     "django_components",
-    "django_components.safer_staticfiles",
+    "django_components.safer_staticfiles",  # replaces django.contrib.staticfiles
     "django_htmx",
     "livecomponents",
     # ...


### PR DESCRIPTION
This may prevent users from running into:
```console
# ./manage.py runserver
[..]
django.core.exceptions.ImproperlyConfigured: Application labels aren't unique, duplicates: staticfiles
``