### PR TITLE
`tests.yml`: Run the CI for more than just upstream pushes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: tests
 
-on: [push]
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 5 * * 1'  # Every Monday at 5am
+  workflow_dispatch:
 
 jobs:
   build-test:


### PR DESCRIPTION
This will now trigger CI:
- **When A pull request is created**: to reduce the chance of merging an external pull request that ends up breaking things
- **Early every Monday**: to learn about the ground shifting early
- **When a member with permissions pushes the "Run workflow" button**: to not need to have to push to trigger new runs to CI

Related: https://crontab.guru/#0_5_*_*_1