### PR TITLE
Add PushUrl execution result and URL navigation demo

### DIFF
--- a/example/myapp/components/urlnavigation/urlnavigation.html
+++ b/example/myapp/components/urlnavigation/urlnavigation.html
@@ -1,0 +1,63 @@
+{% load livecomponents %}
+
+<div {% component_attrs component_id %}>
+  <article>
+    <header>
+      <h2>URL Navigation Demo: Push vs Replace</h2>
+      <p>
+        This demo shows the difference between <code>PushUrl</code> and <code>ReplaceUrl</code>.
+        Try navigating through pages using both methods and observe how the browser's Back button behaves.
+      </p>
+    </header>
+
+    <section>
+      <h3>Current State</h3>
+      <p>
+        <strong>Current Page:</strong> <mark>{{ current_page }}</mark><br>
+        <strong>Navigation Count:</strong> {{ navigation_count }}
+      </p>
+    </section>
+
+    <section>
+      <h3>Navigate with Push URL (Adds to History)</h3>
+      <p>
+        <small>
+          <strong>PushUrl</strong> adds a new entry to browser history.
+          Click through pages, then use your browser's Back button - you'll go through each page you visited.
+        </small>
+      </p>
+      <div role="group">
+        <button hx-post="{% call_command component_id 'navigate_push' %}" hx-vals='{"page": "page1"}'>
+          Go to Page 1 (Push)
+        </button>
+        <button hx-post="{% call_command component_id 'navigate_push' %}" hx-vals='{"page": "page2"}'>
+          Go to Page 2 (Push)
+        </button>
+        <button hx-post="{% call_command component_id 'navigate_push' %}" hx-vals='{"page": "page3"}'>
+          Go to Page 3 (Push)
+        </button>
+      </div>
+    </section>
+
+    <section>
+      <h3>Navigate with Replace URL (Replaces History)</h3>
+      <p>
+        <small>
+          <strong>ReplaceUrl</strong> replaces the current history entry.
+          Click through pages, then use your browser's Back button - you'll skip over the replaced pages.
+        </small>
+      </p>
+      <div role="group">
+        <button hx-post="{% call_command component_id 'navigate_replace' %}" hx-vals='{"page": "page1"}' class="secondary">
+          Go to Page 1 (Replace)
+        </button>
+        <button hx-post="{% call_command component_id 'navigate_replace' %}" hx-vals='{"page": "page2"}' class="secondary">
+          Go to Page 2 (Replace)
+        </button>
+        <button hx-post="{% call_command component_id 'navigate_replace' %}" hx-vals='{"page": "page3"}' class="secondary">
+          Go to Page 3 (Replace)
+        </button>
+      </div>
+    </section>
+  </article>
+</div>

--- a/example/myapp/components/urlnavigation/urlnavigation.py
+++ b/example/myapp/components/urlnavigation/urlnavigation.py
@@ -1,0 +1,33 @@
+from django_components import component
+
+from livecomponents import (
+    LiveComponent,
+    LiveComponentsModel,
+    command,
+)
+from livecomponents.manager.execution_results import ComponentDirty, PushUrl, ReplaceUrl
+
+
+class UrlnavigationState(LiveComponentsModel):
+    current_page: str = "page1"
+    navigation_count: int = 0
+
+
+@component.register("urlnavigation")
+class UrlnavigationComponent(LiveComponent[UrlnavigationState]):
+    template_name = "urlnavigation/urlnavigation.html"
+
+    def init_state(self, context):
+        return UrlnavigationState()
+
+    @command
+    def navigate_push(self, call_context, page: str):
+        call_context.state.current_page = page
+        call_context.state.navigation_count += 1
+        return [ComponentDirty(), PushUrl(f"/urlnavigation/?page={page}")]
+
+    @command
+    def navigate_replace(self, call_context, page: str):
+        call_context.state.current_page = page
+        call_context.state.navigation_count += 1
+        return [ComponentDirty(), ReplaceUrl(f"/urlnavigation/?page={page}")]

--- a/example/myapp/views.py
+++ b/example/myapp/views.py
@@ -56,3 +56,7 @@ def uploads(request: HttpRequest):
 
 def chart(request: HttpRequest):
     return render(request, "chart.html")
+
+
+def urlnavigation(request: HttpRequest):
+    return render(request, "urlnavigation.html")

--- a/example/project/urls.py
+++ b/example/project/urls.py
@@ -8,6 +8,7 @@ from myapp.views import (
     registration,
     simplecounter,
     uploads,
+    urlnavigation,
 )
 
 urlpatterns = [
@@ -19,5 +20,6 @@ urlpatterns = [
     path("registration/", registration, name="registration"),
     path("uploads/", uploads, name="uploads"),
     path("chart/", chart, name="chart"),
+    path("urlnavigation/", urlnavigation, name="urlnavigation"),
     path("livecomponents/", include("livecomponents.urls")),
 ]

--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -45,6 +45,7 @@
       <li><a href="{% url 'registration' %}">Registration</a></li>
       <li><a href="{% url 'uploads' %}">Uploads</a></li>
       <li><a href="{% url 'chart' %}">Chart</a></li>
+      <li><a href="{% url 'urlnavigation' %}">URL Navigation</a></li>
     </ul>
   </nav>
   <hr>

--- a/example/templates/urlnavigation.html
+++ b/example/templates/urlnavigation.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% load livecomponents %}
+
+{% block body %}
+  <h1>URL Navigation Demo</h1>
+  {% livecomponent "urlnavigation" %}
+{% endblock %}

--- a/livecomponents/manager/execution_results.py
+++ b/livecomponents/manager/execution_results.py
@@ -189,6 +189,36 @@ class ReplaceUrl(IExecutionResult):
         results.response_headers["HX-Replace-Url"] = self.url
 
 
+class PushUrl(IExecutionResult):
+    """Push a new URL to the browser history without reloading the page.
+
+    Updates the browser's address bar and adds a new entry to the browser history,
+    allowing users to navigate back to previous states using the browser's back button.
+    See https://htmx.org/headers/hx-push-url/.
+
+    **Example:**
+
+    ```python
+    class WizardComponent(LiveComponent):
+        ...
+
+        @command
+        def next_step(self, call_context: CallContext[WizardState]):
+            \"\"\"Move to next step and update URL with history entry\"\"\"
+            call_context.state.current_step += 1
+            return PushUrl(f'/wizard/step-{call_context.state.current_step}/')
+    ```
+    """  # noqa: E501
+
+    def __init__(self, url: str):
+        """Initialize with the URL to push to the browser history."""
+        self.url = url
+
+    def process(self, state_address: StateAddress, results: "ExecutionResults") -> None:
+        """Set the HX-Push-Url header to push a new URL to browser history."""
+        results.response_headers["HX-Push-Url"] = self.url
+
+
 class ExecutionResults(BaseModel):
     """Container for execution results."""
 


### PR DESCRIPTION
**Core Feature**

- Implement PushUrl execution result class for adding browser history entries
- Add HX-Push-Url header support to push URLs without page reload

**Documentation**

- Document PushUrl in execution results documentation
- Add section comparing PushUrl vs ReplaceUrl use cases
- Include practical examples for navigation and filter scenarios

**Demo Application**

- Create urlnavigation component demonstrating PushUrl and ReplaceUrl
- Add interactive demo showing browser history behavior differences
- Integrate demo into example app navigation