### PR TITLE
[rfc] Resolve misuse(?) of term "DOM"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Django Live Components
 
-Django Live Component is a library to create dynamic web applications that handle user interaction with the DOM on the server. It relies on Django, HTMX, and Alpine.js to provide a seamless experience for developers and users.
+Django Live Component is a library to create dynamic web applications that handle user interaction with server side rendering (SSR). It relies on Django, HTMX, and Alpine.js to provide a seamless experience for developers and users.
 
 To get started, follow the [quickstart guide](https://om-proptech.github.io/livecomponents/quickstart/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Home
 
-Django Live Component is a library for creating dynamic web applications that handle user interactions with the DOM on the server side. It leverages Django, HTMX, and Alpine.js to provide a seamless experience for both developers and users.
+Django Live Component is a library for creating dynamic web applications that handle user interactions with server side rendering (SSR). It leverages Django, HTMX, and Alpine.js to provide a seamless experience for both developers and users.
 
 To get started, follow the [quickstart guide](quickstart.md)
 


### PR DESCRIPTION
In my view, the actual DOM is: https://dom.spec.whatwg.org/