### PR TITLE
`tests.yml`: Cover oldest and most recent supported version of Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,13 @@ on:
 
 jobs:
   build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.11, 3.13]  # oldest and most recent, no need for in-between
+
     runs-on: ubuntu-latest
-    container: python:3.11
+    container: python:${{ matrix.python-version }}
 
     services:
       redis:


### PR DESCRIPTION
This will aid future upgrades to Python 3.12 and beyond.

PS: Python 3.14 support is blocked by e.g. current use of greenlet 3.1.1.