### PR TITLE
Fix StatelessLiveComponent commands returning 410 on stateless-only pages

### DIFF
--- a/docs/component_ids.md
+++ b/docs/component_ids.md
@@ -1,6 +1,6 @@
 # Component IDs
 
-- Every component must have a root element that includes its ID. The ID is `id={{ component_id }}`.
+- Every component must have a root element that includes its ID. The `{% component_attrs component_id %}` template tag sets `data-livecomponent-id` along with other HTMX attributes on this element.
 - Component IDs represent the component hierarchy and are formatted as "|parent:id|child:id". For example, we can have a component |form:0|button:submit where "button" is the component type, "submit" is its name, and "form:0" is its parent.
 
 In many contexts, you get access to the StateAddress object, which consists of the session ID and the component ID.

--- a/docs/context.md
+++ b/docs/context.md
@@ -26,3 +26,20 @@ To address this, add the "save_context" variable:
    {% fill "body" %}Sending a message to {{ user.email }}!{% endfill %}
  {% endlivecomponent_block %}
 ```
+
+## Alternative: capturing context in `init_state()`
+
+The `save_context` approach works at the template level. You can also capture page variables in Python by reading `context.outer_context` inside `init_state()`:
+
+```python
+class SampleState(BaseModel):
+    var: str = "unset"
+
+class Sample(LiveComponent):
+
+    def init_state(self, context: InitStateContext) -> SampleState:
+        var = context.outer_context.get("var", "unset")
+        return SampleState(**context.component_kwargs, var=var)
+```
+
+`outer_context` is only available during the first render. Store anything you need in the component's state so it persists across re-renders.

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -10,13 +10,11 @@ from livecomponents.decorators import livecomponents_login_required
 
 class Something(LiveComponent):
 
-    @classmethod
     @livecomponents_login_required
-    def init_state(cls, context: InitStateContext):
+    def init_state(self, context: InitStateContext):
         ...
 
-    @classmethod
     @livecomponents_login_required
-    def do_something(cls, call_context: CallContext[SomethingState], **kwargs):
+    def do_something(self, call_context: CallContext[SomethingState], **kwargs):
         ...
 ```

--- a/docs/example_project.md
+++ b/docs/example_project.md
@@ -1,8 +1,6 @@
 # Example project
 
-While the fully fledged documentation is not ready and the project is in flux, it's better to use the "example" project as the reference.
-
-Run it locally and play with it to get a better understanding of how the library works.
+The "example" project demonstrates most library features. Run it locally to see how components work in practice.
 
 ```bash
 poetry install

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,12 @@
 # Home
 
-Django Live Component is a library for creating dynamic web applications that handle user interactions with server side rendering (SSR). It leverages Django, HTMX, and Alpine.js to provide a seamless experience for both developers and users.
+Django Live Components adds interactive, stateful UI to Django without a JavaScript frontend. Each component keeps its state on the server (in Redis), renders with standard Django templates, and updates the page through HTMX partial re-renders.
+
+## Why use it?
+
+Plain HTMX requires you to wire up each endpoint, manage state in the session or database, and write the swap logic yourself. Live components handle that plumbing: you define a state class, write command methods that modify it, and the library takes care of serialization, storage, re-rendering, and DOM patching.
+
+If your project already uses Django and you want interactive widgets, like counters, inline editors, live search, or modals, without building a React/Vue frontend or managing HTMX boilerplate by hand, this library is a good fit. For apps that need a full client-side SPA with offline support or complex client-side state, a JS framework is a better choice.
 
 To get started, follow the [quickstart guide](quickstart.md).
 

--- a/docs/livecomponents.md
+++ b/docs/livecomponents.md
@@ -226,7 +226,9 @@ By default, the `PickleStateSerializer` is used. The serializer uses a custom pi
 
 ## Stateless components
 
-If the component doesn't store any state, you can inherit from the StatelessLiveComponent class. You may find this helpful for rendering a hierarchy of components where the shared state is stored in the root components.
+If the component doesn't store any state in livecomponents, you can inherit from the `StatelessLiveComponent` class. This is useful in two scenarios:
+
+**1. Child components that read a parent's state:**
 
 ```python
 from livecomponents.component import StatelessLiveComponent
@@ -243,6 +245,32 @@ class StatelessAlert(StatelessLiveComponent):
         root_state = state_manager.get_component_state(root_addr)
         return {"message": root_state.message}
 ```
+
+**2. Components that manage state externally** (e.g. in a database, a file, or any other storage):
+
+```python
+from livecomponents import CallContext, StatelessLiveComponent, command
+from livecomponents.component import ExtraContextRequest, StatelessModel
+from livecomponents.manager.execution_results import ComponentDirty
+
+from myapp.models import Counter
+
+class ExternalCounter(StatelessLiveComponent):
+
+    template_name = "external_counter.html"
+
+    def get_extra_context_data(
+        self, extra_context_request: ExtraContextRequest[StatelessModel]
+    ) -> dict:
+        return {"count": Counter.objects.get_value()}
+
+    @command
+    def increment(self, call_context: CallContext):
+        Counter.objects.increment()
+        return ComponentDirty()
+```
+
+Stateless components can have their own commands — they don't need a parent component to function. They work standalone on a page just like regular stateful components.
 
 ## Returning results from command handlers
 

--- a/docs/livecomponents.md
+++ b/docs/livecomponents.md
@@ -60,6 +60,10 @@ The livecomponent Python classes are defined in the `simplecounter.py` file. The
 - The component class is a subclass of the `LiveComponent` class.
 - The state class is a subclass of the `BaseModel` class from the `pydantic` library.
 
+!!! note "LiveComponentsModel vs BaseModel"
+
+    You can use either `pydantic.BaseModel` or `livecomponents.LiveComponentsModel` for your state class. `LiveComponentsModel` is a `BaseModel` subclass that sets `arbitrary_types_allowed=True`. Use it when your state holds Django forms, model instances, or other types that Pydantic cannot validate on its own. If your state contains only primitive types and Pydantic models, plain `BaseModel` works fine.
+
 ## Component Python Class
 
 Here's the Python class for the simplecounter component.
@@ -129,6 +133,28 @@ The `{% call_command component_id 'increment' %}` template tag expands to a URL 
 
 On the server side, the command is called by the livecomponent handler, which finds the component class, fetches the state from the store, and calls the command handler. Then the command handler redraws the component and returns the result to the client.
 
+## Request Lifecycle
+
+A full interaction cycle has two phases: initial page load and command execution.
+
+Every rendered component has its own state stored in Redis. The state's address has two coordinates: a **session ID** and a **component ID**. The `{% livecomponents_session_id %}` tag in the base template generates a fresh session ID on each page load. The component ID is built deterministically from the component's type, its own ID, and its parent chain. Each segment is `type:own_id` — for example, `|table:0|row:3` means a `row` component with own ID `3` inside a `table` component with own ID `0`. The own ID defaults to `0`; when you place multiple components of the same type at the same level, pass a distinct `own_id` to each (e.g., `{% livecomponent "clickcounter" own_id="1" %}`). Together, the session ID and the full component ID form a `StateAddress` — the key the library uses to store and retrieve that component's state.
+
+**Page load:**
+
+1. The browser requests a page. Django renders the template, which contains `{% livecomponent %}` tags.
+2. For each component, the library calls `init_state()` to create the initial state, serializes it with Pickle, and stores it in Redis under the component's `StateAddress`.
+3. The component template renders with the state fields as context variables. The root element gets HTMX attributes (`hx-swap-oob`, `data-livecomponent-id`, `key`) via `{% component_attrs %}`.
+
+**Command execution:**
+
+1. The user clicks a button (or triggers another HTMX event). HTMX sends a POST to `/livecomponents/call_command/` with the session ID, component ID, and command name.
+2. The `call_command` view loads the component's state from Redis and deserializes it.
+3. The `@command` method runs, receiving a `CallContext` with the current state. The method modifies the state as needed and returns execution results (or `None` for default behavior).
+4. The library saves the updated state to Redis, re-renders the component template, and returns the HTML.
+5. HTMX swaps the new HTML into the DOM.
+
+If the session has expired (e.g., the Redis key's 24-hour TTL elapsed), the view returns HTTP 410 Gone.
+
 ## Component State
 
 The state is defined in a separate class. The state must include parameters passed to the component as keyword arguments, so that the component gets all the necessary information to re-render itself on partial render.
@@ -164,15 +190,31 @@ class Alert(LiveComponent):
         return AlertState(**context.component_kwargs)
 ```
 
-Component states don't need to be stored if components are not expected to be re-rendered independently, and only as part of the parent component. For example, components for buttons are rarely re-rendered independently, so you can get away without the state model.
+Components that only re-render as part of their parent can skip state entirely. Inherit from `StatelessLiveComponent` instead (see [Stateless components](#stateless-components) below). A button that calls a command on its parent is a typical example.
+
+::: livecomponents.manager.manager.InitStateContext
+    options:
+      heading_level: 3
+      show_root_heading: true
+      members: false
+
+::: livecomponents.manager.manager.UpdateStateContext
+    options:
+      heading_level: 3
+      show_root_heading: true
+      members: false
+
+::: livecomponents.component.ExtraContextRequest
+    options:
+      heading_level: 3
+      show_root_heading: true
+      members: false
 
 ## Serializing Component State
 
-When the page is rendered for the first time, a new session is created, and each component is initialized with its state by calling the `init_state()` method.
+As described in [Request Lifecycle](#request-lifecycle), the state is serialized and stored in Redis on the first render, then reused for the lifetime of the session (until the page is reloaded or the TTL expires).
 
-The state is then serialized and stored in the session store, and as long as the session is the same (in other words, while the page is not reloaded), the state is reused.
-
-The state is serialized using the `StateSerializer` class and saved in Redis. By default, the `PickleStateSerializer` is used. The serializer uses a custom pickler and is optimized to effectively store the most common types of data used in a Django app. More specifically:
+By default, the `PickleStateSerializer` is used. The serializer uses a custom pickler and is optimized to effectively store the most common types of data used in a Django app. More specifically:
 
 - When serializing a Django model, only the model's name and primary key are stored. The serializer takes advantage of the persistent_id/persistent_load pickle mechanism.
 - When serializing a Pydantic model, only the model's name and the values of the fields are stored.
@@ -248,7 +290,7 @@ We encountered this situation at least once, where a race condition caused the p
 
 There are several ways to call component methods from other components:
 
-**Using the component ID.** For example, if you have a component with ID "|message.0" and a method "set_message", you can call it like this:
+**Using the component ID.** For example, if you have a component with ID "|message:0" and a method "set_message", you can call it like this:
 
 ```python
 from livecomponents import LiveComponent, command, CallContext
@@ -272,3 +314,16 @@ class MyComponent(LiveComponent):
     def do_something(self, call_context: CallContext):
         call_context.parent.set_message("Hello, world!")
 ```
+
+::: livecomponents.manager.manager.CallContext
+    options:
+      heading_level: 2
+      show_root_heading: true
+
+::: livecomponents.manager.manager.StateManager
+    options:
+      heading_level: 2
+      show_root_heading: true
+      members:
+        - get_component_state
+        - set_component_state

--- a/docs/management_commands.md
+++ b/docs/management_commands.md
@@ -36,7 +36,7 @@ This command will create the files:
 - `counters/components/counters/click_counter/click_counter.py` (Python file with the component class)
 - `counters/components/counters/click_counter/click_counter.html` (HTML template for the component)
 
-#### Create Minimal Statless Component
+#### Create Minimal Stateless Component
 
 ```sh
 python manage.py createlivecomponent counters counters/click_counter --stateless --minimal

--- a/docs/nested_components.md
+++ b/docs/nested_components.md
@@ -10,7 +10,7 @@ Let's explore this pattern in detail.
 
 The idea behind this pattern is to create a single component (typically called "myapp/root") that maintains the entire state and contains all the actions that can modify this state.
 
-Child components are stateless and don't have any actions. Their Django templates call the actions defined in their root component.
+Child components are stateless and typically delegate actions to the root component via its command handlers.
 
 While this approach makes the root and child components tightly coupled (you can't use child components independently), it makes the data flow easier to understand. Additionally, all logic is concentrated in a single place.
 

--- a/docs/nested_components.md
+++ b/docs/nested_components.md
@@ -68,7 +68,7 @@ In this simple example, we could create both the current value display and the i
 
 <div {% component_attrs component_id %}>
     Counter: {{ value }}
-    <button {% component_attrs component_id %}
+    <button
         hx-post='{% call_command component_id "increment" %}'
         hx-vals='{"value": 1}'
     >

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,7 +61,7 @@ TEMPLATES = [
 ]
 ```
 
-Add component dirs for to static files:
+Add component dirs to static files:
 
 ```python
 # Static files (CSS, JavaScript, Images)
@@ -79,7 +79,7 @@ You can also configure live components with the `LIVECOMPONENTS` settings dictio
 There, we need support for HTMX and Live Components:
 
 ```html
-{% load ... component_tags django_htmx livecomponents %}
+{% load component_tags django_htmx livecomponents %}
 <head>
   <!-- Configure HTMX. See https://htmx.org/docs/#config -->
   <meta name="htmx-config" content='{"defaultSwapStyle":"none","allowNestedOobSwaps":false}'>
@@ -125,7 +125,7 @@ There, we need support for HTMX and Live Components:
 ...
 {% component_js_dependencies %}
 </body>
-<html>
+</html>
 ```
 
 ## Project `urls.py`

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -26,17 +26,17 @@ We introduce new flat tags "livecomponent" and block tags "livecomponent_block".
 It would be wasteful to store the entire HTML template for every component, considering that most components are rendered by the same template. To optimize space, we hash the template content and use it as the cache key:
 
 ```redis
-127.0.0.1:6379> get template_cache:LkAl5ah3
+127.0.0.1:6379> get lc:template_cache:LkAl5ah3
 "{% livecomponent \"search\" parent_id=component_id search=search %}"
 ```
 
-Then, we have a separate Redis HASH "templates:<session_id>" to map from component IDs to template hashes:
+Then, we have a separate Redis HASH "lc:templates:<session_id>" to map from component IDs to template hashes:
 
 ```redis
-127.0.0.1:6379> hgetall templates:a99377ffe6a946e496542ac2c8a8cb96
- 1) "/table.0"
+127.0.0.1:6379> hgetall lc:templates:a99377ffe6a946e496542ac2c8a8cb96
+ 1) "|table:0"
  2) "rPOwF_re"
- 3) "/table.0/search.0"
+ 3) "|table:0|search:0"
  4) "LkAl5ah3"
  ...
 ```

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -26,4 +26,4 @@ Here's an example of how the handler can look:
         ...
 ```
 
-You can see a full example in the [uploads](https://github.com/om-proptech/livecomponents/tree/main/example/uploads) app of the sample project.
+You can see a full example in the [csvviewer](https://github.com/om-proptech/livecomponents/tree/main/example/myapp/components/csvviewer) component of the sample project.

--- a/example/myapp/components/statelesscounter/statelesscounter.html
+++ b/example/myapp/components/statelesscounter/statelesscounter.html
@@ -1,0 +1,7 @@
+{% load livecomponents %}
+
+<div {% component_attrs component_id %} style="display: flex; gap: 10px;">
+    <button style="width: 100px" hx-post="{% call_command component_id 'decrement' %}">-1</button>
+    <button style="width: 100px" hx-post="{% call_command component_id 'increment' %}">+1</button>
+    <div style="font-size: 2rem;">Count: {{ count }}</div>
+</div>

--- a/example/myapp/components/statelesscounter/statelesscounter.py
+++ b/example/myapp/components/statelesscounter/statelesscounter.py
@@ -1,0 +1,40 @@
+from django_components import component
+
+from livecomponents import CallContext, StatelessLiveComponent, command
+from livecomponents.component import ExtraContextRequest, StatelessModel
+from livecomponents.manager.execution_results import ComponentDirty
+
+# A global variable simulating external storage (database, file, Redis, etc.).
+# The point: the component is "stateless" from livecomponents' perspective,
+# but it still has state — just managed elsewhere.
+_counter_value = 0
+
+
+@component.register("statelesscounter")
+class StatelessCounterComponent(StatelessLiveComponent):
+    """A counter that stores its value outside of livecomponents.
+
+    Demonstrates that StatelessLiveComponent can have commands and manage
+    state externally (e.g. in a database, a file, or — as here — a global
+    variable).
+    """
+
+    template_name = "statelesscounter/statelesscounter.html"
+
+    def get_extra_context_data(
+        self, extra_context_request: ExtraContextRequest[StatelessModel]
+    ) -> dict:
+        return {"count": _counter_value}
+
+    @command
+    def increment(self, call_context: CallContext):
+        global _counter_value
+        _counter_value += 1
+        return ComponentDirty()
+
+    @command
+    def decrement(self, call_context: CallContext):
+        global _counter_value
+        _counter_value -= 1
+        return ComponentDirty()
+

--- a/example/myapp/components/statelesscounter/statelesscounter.py
+++ b/example/myapp/components/statelesscounter/statelesscounter.py
@@ -37,4 +37,3 @@ class StatelessCounterComponent(StatelessLiveComponent):
         global _counter_value
         _counter_value -= 1
         return ComponentDirty()
-

--- a/example/myapp/views.py
+++ b/example/myapp/views.py
@@ -64,3 +64,7 @@ def urlnavigation(request: HttpRequest):
 
 def notification(request: HttpRequest):
     return render(request, "notification.html")
+
+
+def statelesscounter(request: HttpRequest):
+    return render(request, "statelesscounter.html")

--- a/example/project/urls.py
+++ b/example/project/urls.py
@@ -8,8 +8,8 @@ from myapp.views import (
     notification,
     registration,
     simplecounter,
-    uploads,
     statelesscounter,
+    uploads,
     urlnavigation,
 )
 

--- a/example/project/urls.py
+++ b/example/project/urls.py
@@ -9,6 +9,7 @@ from myapp.views import (
     registration,
     simplecounter,
     uploads,
+    statelesscounter,
     urlnavigation,
 )
 
@@ -23,5 +24,6 @@ urlpatterns = [
     path("chart/", chart, name="chart"),
     path("urlnavigation/", urlnavigation, name="urlnavigation"),
     path("notification/", notification, name="notification"),
+    path("statelesscounter/", statelesscounter, name="statelesscounter"),
     path("livecomponents/", include("livecomponents.urls")),
 ]

--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -36,10 +36,11 @@
       _="on htmx:responseError[detail.xhr.status == 410] window.location.reload()"
 >
 <main class="container">
-  <nav>
-    <ul>
+  <nav style="overflow-x: auto;">
+    <ul style="flex-wrap: wrap;">
       <li><a href="{% url 'counters_index' %}">Counters</a></li>
       <li><a href="{% url 'simplecounter' %}">Simple counter</a></li>
+      <li><a href="{% url 'statelesscounter' %}">Stateless counter</a></li>
       <li><a href="{% url 'coffee' %}">Coffee beans</a></li>
       <li><a href="{% url 'modals' %}">Modals</a></li>
       <li><a href="{% url 'registration' %}">Registration</a></li>

--- a/example/templates/statelesscounter.html
+++ b/example/templates/statelesscounter.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% load livecomponents %}
+
+{% block body %}
+  <h1>Stateless counter</h1>
+  <p>The counter value lives in a global variable — outside of livecomponents — demonstrating that state can be managed externally (e.g. in a database or file).</p>
+  {% livecomponent "statelesscounter" %}
+{% endblock %}

--- a/livecomponents/component.py
+++ b/livecomponents/component.py
@@ -227,6 +227,21 @@ class StatelessLiveComponent(LiveComponent[StatelessModel]):
 
 
 class ExtraContextRequest(LiveComponentsModel, Generic[State]):
+    """Passed to `get_extra_context_data()` on every render.
+
+    Use it to compute template context that depends on state or on other
+    components' state.
+
+    Attributes:
+        request: The current Django request.
+        state: The component's current state.
+        state_manager: The StateManager instance. Useful for reading another
+            component's state — call `state_manager.get_component_state(addr)`.
+        state_addr: The component's StateAddress (session ID + component ID).
+        component_kwargs: Keyword arguments from the template tag. Empty on
+            command-triggered re-renders.
+    """
+
     request: HttpRequest
     state: State
     state_manager: StateManager

--- a/livecomponents/component.py
+++ b/livecomponents/component.py
@@ -220,6 +220,10 @@ class StatelessLiveComponent(LiveComponent[StatelessModel]):
         request: HttpRequest,
         component_kwargs: dict[str, Any],
     ) -> StatelessModel:
+        # Stateless components never write state to the store, so the session
+        # would not be discoverable by session_exists(). Register a lightweight
+        # sentinel to prevent call_command from returning 410.
+        state_manager.ensure_session(state_addr.session_id)
         return StatelessModel()
 
     def init_state(self, context: InitStateContext) -> StatelessModel:

--- a/livecomponents/decorators.py
+++ b/livecomponents/decorators.py
@@ -11,14 +11,12 @@ def livecomponents_login_required(method):
 
     class Something(LiveComponent):
 
-        @classmethod
         @livecomponents_login_required
-        def init_state(cls, context: InitStateContext):
+        def init_state(self, context: InitStateContext):
             ...
 
-        @classmethod
         @livecomponents_login_required
-        def do_something(cls, call_context: CallContext[SomethingState]):
+        def do_something(self, call_context: CallContext[SomethingState]):
             ...
     """
     if method.__name__ == "init_state":
@@ -29,19 +27,19 @@ def livecomponents_login_required(method):
 
 def _init_state_login_required(method):
     @wraps(method)
-    def wrapped(cls, context: InitStateContext, **component_kwargs):
+    def wrapped(self, context: InitStateContext, **component_kwargs):
         if not context.request.user.is_authenticated:
             raise PermissionDenied()
-        return method(cls, context, **component_kwargs)
+        return method(self, context, **component_kwargs)
 
     return wrapped
 
 
 def _call_method_login_required(method):
     @wraps(method)
-    def wrapped(cls, call_context: CallContext, **kwargs):
+    def wrapped(self, call_context: CallContext, **kwargs):
         if not call_context.request.user.is_authenticated:
             raise PermissionDenied()
-        return method(cls, call_context, **kwargs)
+        return method(self, call_context, **kwargs)
 
     return wrapped

--- a/livecomponents/manager/manager.py
+++ b/livecomponents/manager/manager.py
@@ -183,6 +183,14 @@ class StateManager:
     def session_exists(self, session_id: str) -> bool:
         return self.store.session_exists(session_id)
 
+    def ensure_session(self, session_id: str) -> None:
+        """Ensure the session is registered in the store.
+
+        Called during initial render so that even pages with only stateless
+        components have a discoverable session.
+        """
+        self.store.ensure_session(session_id)
+
     def component_initialized(self, state_addr: StateAddress) -> bool:
         return self.store.component_initialized(state_addr)
 

--- a/livecomponents/manager/manager.py
+++ b/livecomponents/manager/manager.py
@@ -29,6 +29,30 @@ DEFAULT_CONTEXT_IGNORE_KEYS = {
 
 
 class CallContext(LiveComponentsModel, Generic[State]):
+    """Passed to every `@command` method as the first argument (after `self`).
+
+    Provides access to the component's state and lets you navigate to other
+    components in the hierarchy.
+
+    You can call any command on another component by chaining navigation with
+    a method call. For example, `call_context.parent.set_message("Hello")`
+    executes the `set_message` command on the parent component. This works
+    because `find_one()`, `find_ancestor()`, and `parent` each return a new
+    `CallContext`, and any unknown attribute access on a `CallContext` is
+    dispatched as a command call on that component.
+
+    Attributes:
+        request: The Django request that triggered the command.
+        state: The component's current state. Modify it directly; the library
+            saves it after the command returns.
+        state_address: The component's session ID and component ID.
+        state_manager: The StateManager instance. Rarely needed directly; prefer
+            `find_one()`, `find_ancestor()`, or `parent` instead.
+        execution_results: Internal bookkeeping. Tracks which components need
+            re-rendering after the command runs. You should not need to access
+            this directly; return execution results from your command instead.
+    """
+
     request: HttpRequest
     state: State
     state_address: StateAddress
@@ -36,14 +60,18 @@ class CallContext(LiveComponentsModel, Generic[State]):
     execution_results: ExecutionResults = Field(default_factory=ExecutionResults)
 
     def find_one(self, component_id: str) -> "CallContext":
-        """Find a component by its ID."""
+        """Return a CallContext for the component with the given ID.
+
+        Call command methods on the result to execute them on the target
+        component. For example: `call_context.find_one("|message:0").set_message("Hi")`.
+        """
         state = self.state_manager.get_component_state(
             self.state_address.model_copy(update={"component_id": component_id})
         )
         return self.model_copy(update={"component_id": component_id, "state": state})
 
     def find_ancestor(self, ancestor_type: str) -> "CallContext":
-        """Find the closest ancestor of the given type."""
+        """Find the closest ancestor of the given type in the hierarchy."""
         ancestor = self.state_address.must_find_ancestor(ancestor_type)
         ancestor_state = self.state_manager.get_component_state(ancestor)
         return self.model_copy(
@@ -52,10 +80,17 @@ class CallContext(LiveComponentsModel, Generic[State]):
 
     @property
     def parent(self) -> "CallContext":
+        """Shortcut for the immediate parent component's CallContext."""
         return self.find_one(self.state_address.must_get_parent().component_id)
 
     def __getattr__(self, command_name: str):
-        """This is called when a method is called on the CallContext."""
+        """Dispatch unknown attribute access as a command call on this component.
+
+        This is the mechanism behind `call_context.parent.set_message("Hello")`.
+        `parent` returns a `CallContext` for the parent component, and
+        `.set_message("Hello")` hits `__getattr__`, which executes the
+        `set_message` command on that parent with `{"message": "Hello"}` as kwargs.
+        """
 
         def call(**kwargs):
             self.state_manager.call_with_context(
@@ -69,6 +104,23 @@ class CallContext(LiveComponentsModel, Generic[State]):
 
 
 class InitStateContext(LiveComponentsModel):
+    """Passed to `init_state()` on a component's first render.
+
+    Attributes:
+        request: The current Django request.
+        state_addr: The component's StateAddress (session ID + component ID).
+        state_manager: The StateManager instance. Useful for reading another
+            component's state — call `state_manager.get_component_state(addr)`.
+        component_kwargs: Keyword arguments from the template tag. For example,
+            `{{% livecomponent "alert" message="Hello" %}}` yields
+            `{{"message": "Hello"}}`.
+        outer_context: The Django template context of the page that rendered
+            this component. Only available during the first render. Read page-level
+            variables here and store them in state if the component needs them
+            on re-render. See [On Storing Raw HTML Templates](templates.md) for
+            an example.
+    """
+
     request: HttpRequest
     state_addr: StateAddress
     state_manager: "StateManager"
@@ -77,6 +129,22 @@ class InitStateContext(LiveComponentsModel):
 
 
 class UpdateStateContext(LiveComponentsModel, Generic[State]):
+    """Passed to `update_state()` when an already-initialized component re-renders.
+
+    Has the same fields as `InitStateContext` plus `state` — the existing
+    state loaded from Redis.
+
+    Attributes:
+        request: The current Django request.
+        state_addr: The component's StateAddress (session ID + component ID).
+        state_manager: The StateManager instance.
+        component_kwargs: Keyword arguments from the template tag. Empty when
+            the component re-renders from its own command.
+        outer_context: The Django template context of the containing page.
+            See `InitStateContext.outer_context` for details.
+        state: The component's existing state. Modify it in place.
+    """
+
     request: HttpRequest
     state_addr: StateAddress
     state_manager: "StateManager"
@@ -86,6 +154,19 @@ class UpdateStateContext(LiveComponentsModel, Generic[State]):
 
 
 class StateManager:
+    """Manages component state persistence and command execution.
+
+    Most of the time you interact with StateManager indirectly — through
+    `CallContext` methods like `find_one()` or `parent`. The two methods
+    useful in component code are:
+
+    - `get_component_state(state_addr)` — load another component's state.
+    - `set_component_state(state_addr, state)` — save another component's state.
+
+    These are handy in `get_extra_context_data()` of stateless components
+    that need to read their root component's state.
+    """
+
     def __init__(self, serializer: IStateSerializer, store: IStateStore):
         self.serializer = serializer
         self.store = store
@@ -140,6 +221,10 @@ class StateManager:
         return state
 
     def get_component_state(self, state_addr: StateAddress) -> Any | None:
+        """Load a component's state from Redis by its StateAddress.
+
+        Returns None if the component has not been initialized yet.
+        """
         raw_state = self.store.restore_state(state_addr)
         if raw_state is None:
             return None
@@ -148,6 +233,7 @@ class StateManager:
         return state
 
     def set_component_state(self, state_addr: StateAddress, state: Any):
+        """Save a component's state to Redis."""
         logger.debug(
             "Setting component state for %r: %r", state_addr.component_id, state
         )

--- a/livecomponents/manager/stores.py
+++ b/livecomponents/manager/stores.py
@@ -44,6 +44,16 @@ class IStateStore(abc.ABC):
         ...
 
     @abc.abstractmethod
+    def ensure_session(self, session_id: str) -> None:
+        """Ensure the session exists in the store.
+
+        This is idempotent: calling it multiple times has no additional effect.
+        Used to register sessions for pages that contain only stateless
+        components, which otherwise never write to the state store.
+        """
+        ...
+
+    @abc.abstractmethod
     def clear_session(self, session_id: str) -> None:
         ...
 
@@ -87,6 +97,10 @@ class MemoryStateStore(IStateStore):
 
     def restore_component_template(self, state_addr: StateAddress) -> bytes | None:
         return self._components.get(state_addr)
+
+    def ensure_session(self, session_id: str) -> None:
+        sentinel = StateAddress(session_id=session_id, component_id="__session__")
+        self._store.setdefault(sentinel, b"")
 
     def clear_session(self, session_id: str) -> None:
         for state_addr in list(self._store.keys()):
@@ -213,6 +227,13 @@ class RedisStateStore(IStateStore):
             self.template_cache_prefix, hashed_value.decode("ascii")
         )
         return self.client.get(cache_key)
+
+    def ensure_session(self, session_id: str) -> None:
+        key_name = self._get_key_name(self.key_prefix, session_id)
+        with self.client.pipeline() as pipe:
+            pipe.hsetnx(key_name, "__session__", b"1")
+            pipe.expire(key_name, self.ttl)
+            pipe.execute()
 
     def clear_session(self, session_id: str) -> None:
         with self.client.pipeline() as pipe:

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -89,6 +89,22 @@ def test_modals(live_server, page: Page):
     expect(page.get_by_test_id("modal").first).to_be_hidden()
 
 
+def test_stateless_counter(live_server, page: Page):
+    statelesscounter_url = str(live_server) + reverse("statelesscounter")
+
+    page.set_default_timeout(5_000)
+    page.goto(statelesscounter_url)
+
+    count = page.locator("div", has_text="Count:").last
+    expect(count).to_contain_text("Count: 0")
+
+    page.get_by_role("button", name="+1").click()
+    expect(count).to_contain_text("Count: 1")
+
+    page.get_by_role("button", name="-1").click()
+    expect(count).to_contain_text("Count: 0")
+
+
 def test_uploads(live_server, page: Page):
     uploads_url = str(live_server) + reverse("uploads")
 

--- a/tests/test_redis_state_store.py
+++ b/tests/test_redis_state_store.py
@@ -45,6 +45,39 @@ def test_clear_session_and_then_save_state_recovers_ttl(redis_state_store):
     )
 
 
+def test_ensure_session_makes_session_discoverable(redis_state_store):
+    session_id = "stateless-session"
+    assert not redis_state_store.session_exists(session_id)
+    redis_state_store.ensure_session(session_id)
+    assert redis_state_store.session_exists(session_id)
+
+
+def test_ensure_session_is_idempotent(redis_state_store):
+    session_id = "stateless-session"
+    redis_state_store.ensure_session(session_id)
+    redis_state_store.ensure_session(session_id)
+    assert redis_state_store.session_exists(session_id)
+
+
+def test_ensure_session_does_not_overwrite_existing_state(redis_state_store):
+    state_addr = StateAddress(session_id="session_id", component_id="|root:0")
+    redis_state_store.save_state(state_addr, b"real-state")
+    redis_state_store.ensure_session("session_id")
+    assert redis_state_store.restore_state(state_addr) == b"real-state"
+
+
+def test_ensure_session_sets_ttl(redis_state_store):
+    session_id = "stateless-session"
+    redis_state_store.ensure_session(session_id)
+    state_key = redis_state_store._get_key_name(
+        redis_state_store.key_prefix, session_id
+    )
+    assert (
+        redis_state_store.client.ttl(state_key)
+        > redis_state_store.ttl.total_seconds() - 10
+    )
+
+
 def get_state_key(redis_state_store, state_addr):
     return redis_state_store._get_key_name(
         redis_state_store.key_prefix, state_addr.session_id

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,6 +18,13 @@ def test_missing_session_returns_410_gone(client, state_manager):
     assert resp.status_code == 410
 
 
+def test_ensure_session_prevents_410_for_stateless_components(client, state_manager):
+    """After ensure_session(), call_command should not return 410."""
+    session_id = "stateless-only-session"
+    state_manager.ensure_session(session_id)
+    assert state_manager.session_exists(session_id)
+
+
 def test_parse_body_understands_json_encoded_content(rf):
     request = rf.post(
         "/",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,8 +18,8 @@ def test_missing_session_returns_410_gone(client, state_manager):
     assert resp.status_code == 410
 
 
-def test_ensure_session_prevents_410_for_stateless_components(client, state_manager):
-    """After ensure_session(), call_command should not return 410."""
+def test_ensure_session_makes_session_discoverable(state_manager):
+    """ensure_session() registers the session so that session_exists() returns True."""
     session_id = "stateless-only-session"
     state_manager.ensure_session(session_id)
     assert state_manager.session_exists(session_id)


### PR DESCRIPTION
## Summary

Fixes #33. Pages with **only** stateless components returned HTTP 410 on every command call because `StatelessLiveComponent` never writes to the state store, so `session_exists()` returned `False`.

- Add `ensure_session()` to `IStateStore` / `StateManager` — writes an idempotent `__session__` sentinel via `HSETNX` so the session becomes discoverable without storing real state
- Call it from `StatelessLiveComponent.get_or_create_state()` only — stateful components are unaffected
- Add `statelesscounter` example: a counter storing its value in a global variable (simulating external storage)
- Add unit, Redis store, and Playwright E2E tests
- Expand docs to cover standalone stateless components with externally-managed state

## Test plan

- [x] All 59 unit tests pass (`poetry run pytest tests/ --ignore=tests/test_example.py`)
- [x] Playwright E2E test passes (`test_stateless_counter`)
- [ ] Manual: visit `/statelesscounter/`, click +1/-1, verify count updates (no 410 in network tab)
- [ ] Manual: visit a stateful page (e.g. `/simplecounter/`), verify no `__session__` key appears in `hgetall lc:states:{session_id}`